### PR TITLE
Add alternative zoom mechanisms

### DIFF
--- a/include/MainWindow.hpp
+++ b/include/MainWindow.hpp
@@ -100,6 +100,10 @@ private slots:
             );
     void pasteEdit(
             );
+    void zoomIn(
+            );
+    void zoomOut(
+            );
     void nodeSlot(
             QAction* _action
             );
@@ -147,6 +151,7 @@ private:
 
     QMenu* m_fileMenu;
     QMenu* m_editMenu;
+    QMenu* m_viewMenu;
     QMenu* m_nodesMenu;
     QMenu* m_postitMenu;
 
@@ -161,6 +166,8 @@ private:
     QAction* m_cutAct;
     QAction* m_copyAct;
     QAction* m_pasteAct;
+    QAction* m_zoomInAct;
+    QAction* m_zoomOutAct;
     QAction* m_postitAct;
 
     QJsonObject m_clipboard;

--- a/include/NodeEditor/NodeEditor.hpp
+++ b/include/NodeEditor/NodeEditor.hpp
@@ -69,6 +69,10 @@ public:
             QKeyEvent* _event
             );
     //
+    void zoom(
+            float zoomFactor
+            );
+    //
     void saveToJson(
             QJsonObject& _json
             );

--- a/include/NodeEditor/NodeEditor.hpp
+++ b/include/NodeEditor/NodeEditor.hpp
@@ -61,10 +61,6 @@ public:
             QEvent* _event
             );
     //
-    void wheelEvent(
-            QWheelEvent* _event
-            );
-    //
     void keyPressEvent(
             QKeyEvent* _event
             );
@@ -161,10 +157,6 @@ private:
 //    QList<SelectionBox*> m_selections;
     //
     NodeTreeEditor* m_treeModel;
-    //
-    bool m_scrollTimerActive;
-    //
-    int m_scrollDelta;
 };
 
 #endif // NODEEDITOR_HPP

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -455,6 +455,20 @@ void MainWindow::pasteEdit(
     m_nodeEditors[m_currentFileIndex]->addNode(m_clipboard);
 }
 
+void MainWindow::zoomIn(
+        )
+{
+    float zoomFactor = 1 / 0.9;
+    m_nodeEditors[m_currentFileIndex]->zoom(zoomFactor);
+}
+
+void MainWindow::zoomOut(
+        )
+{
+    float zoomFactor = 0.9;
+    m_nodeEditors[m_currentFileIndex]->zoom(zoomFactor);
+}
+
 void MainWindow::addNode(
         const NodeSetting* _setting
         )
@@ -516,6 +530,10 @@ void MainWindow::createMenus()
     m_editMenu->addAction(m_cutAct);
     m_editMenu->addAction(m_copyAct);
     m_editMenu->addAction(m_pasteAct);
+
+    m_viewMenu = menuBar()->addMenu(tr("View"));
+    m_viewMenu->addAction(m_zoomInAct);
+    m_viewMenu->addAction(m_zoomOutAct);
 
     m_nodesMenu = menuBar()->addMenu(tr("Nodes"));
     m_nodesMenu->addAction(m_loadNodesAct);
@@ -582,6 +600,16 @@ void MainWindow::createActions()
     m_pasteAct->setShortcuts(QKeySequence::Paste);
     m_pasteAct->setStatusTip(tr("Paste the clipboard's contents into the current selection"));
     connect(m_pasteAct, SIGNAL(triggered()), this, SLOT(pasteEdit()));
+
+    m_zoomInAct = new QAction(tr("Zoom In"), this);
+    m_zoomInAct->setShortcuts(QKeySequence::ZoomIn);
+    m_zoomInAct->setStatusTip(tr("Zoom in the node editor"));
+    connect(m_zoomInAct, SIGNAL(triggered()), this, SLOT(zoomIn()));
+
+    m_zoomOutAct = new QAction(tr("Zoom out"), this);
+    m_zoomOutAct->setShortcuts(QKeySequence::ZoomOut);
+    m_zoomOutAct->setStatusTip(tr("Zoom out the node editor"));
+    connect(m_zoomOutAct, SIGNAL(triggered()), this, SLOT(zoomOut()));
 
     m_postitAct = new QAction(tr("Post-it"), this);
     connect(m_postitAct, SIGNAL(triggered()), this, SLOT(addPostIt()));

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -84,6 +84,22 @@ MainWindow::MainWindow(
     mainWidget->addWidget(m_nodeTreeWidget);
     QSplitter* rightWidget = new QSplitter(Qt::Vertical, mainWidget);
 
+    // Create a widget containing the zoom buttons
+    QWidget* zoomWidget = new QWidget();
+    QHBoxLayout* buttonLayout = new QHBoxLayout(zoomWidget);
+    buttonLayout->setSpacing(0);
+    QPushButton* buttonZoomIn = new QPushButton("+");
+    QPushButton* buttonZoomOut = new QPushButton("—");
+    buttonLayout->addWidget(buttonZoomIn);
+    buttonLayout->addWidget(buttonZoomOut);
+
+    // Create a grid layout allowing for the placement of buttons on the node editor
+    QGridLayout* nodeEditorLayout = new QGridLayout();
+    nodeEditorLayout->addWidget(zoomWidget, 1, 0);
+    nodeEditorLayout->setRowStretch(0, 1);
+    nodeEditorLayout->setColumnStretch(1, 1);
+    m_nodeEditorWidget->setLayout(nodeEditorLayout);
+
     QSplitter* nodeEditor = new QSplitter(Qt::Horizontal, rightWidget);
     m_nodeEditorWidget->setTabsClosable(true);
     nodeEditor->addWidget(m_nodeEditorWidget);
@@ -115,6 +131,8 @@ MainWindow::MainWindow(
 
     connect(buttonGenerate, SIGNAL(released()), this, SLOT(nodeToCode()));
     connect(buttonSave, SIGNAL(released()), this, SLOT(saveCode()));
+    connect(buttonZoomIn, SIGNAL(released()), this, SLOT(zoomIn()));
+    connect(buttonZoomOut, SIGNAL(released()), this, SLOT(zoomOut()));
     connect(m_nodeEditorWidget, SIGNAL(currentChanged(int)), this, SLOT(setFileAt(int)));
     connect(m_nodeEditorWidget, SIGNAL(tabCloseRequested(int)), this, SLOT(closeTab(int)));
 

--- a/src/NodeEditor/NodeEditor.cpp
+++ b/src/NodeEditor/NodeEditor.cpp
@@ -260,33 +260,27 @@ void NodeEditor::wheelEvent(
         QWheelEvent* _event
         )
 {
+    //// @note Scrollwheel zoom disabled until upstream Qt bugs are fixed or suitable work-around is found
     // When a wheelEvent is fired, a single-shot timer is created and delta values accumalated
     // from all wheelEvents fired during that timer. When the timer is not active, the scroll is
     // performed using the accumalated delta value. This is a temporary fix until QTBug-226 is fixed.
-    this->m_scrollDelta += _event->delta();
-    if (!m_scrollTimerActive) {
-        float scalingStep = 0.9;
-        if(this->m_scrollDelta < 0)
-        {
-            this->scale(scalingStep, scalingStep);
-            m_scalingFactor *= scalingStep;
-        }
-        else
-        {
-            this->scale(1 / scalingStep, 1 / scalingStep);
-            m_scalingFactor /= scalingStep;
-        }
+//    this->m_scrollDelta += _event->delta();
+//    if (!m_scrollTimerActive) {
+//        float scalingStep = 0.9;
+//        if(this->m_scrollDelta < 0)
+//        {
+//            this->zoom(scalingStep);
+//        }
+//        else
+//        {
+//            this->zoom(1/scalingStep);
+//        }
 
-        this->m_scrollDelta = 0;
-        this->m_scrollTimerActive = true;
-        QTimer::singleShot(23, this, [=]() {
-            this->m_scrollTimerActive = false;
-        });
-    }
-    /// @todo pass on to selections
-//    foreach (SelectionBox* selection, m_selections)
-//    {
-//        selection->updateOpacity(m_scalingFactor);
+//        this->m_scrollDelta = 0;
+//        this->m_scrollTimerActive = true;
+//        QTimer::singleShot(23, this, [=]() {
+//            this->m_scrollTimerActive = false;
+//        });
 //    }
 }
 
@@ -327,6 +321,17 @@ void NodeEditor::keyPressEvent(
         break;
     }
     }
+}
+
+void NodeEditor::zoom(float zoomFactor) {
+    this->scale(zoomFactor, zoomFactor);
+    m_scalingFactor *= zoomFactor;
+
+    /// @todo pass on to selections
+//    foreach (SelectionBox* selection, m_selections)
+//    {
+//        selection->updateOpacity(m_scalingFactor);
+//    }
 }
 
 const QGraphicsItem* NodeEditor::itemAt(

--- a/src/NodeEditor/NodeEditor.cpp
+++ b/src/NodeEditor/NodeEditor.cpp
@@ -264,24 +264,24 @@ void NodeEditor::wheelEvent(
     // When a wheelEvent is fired, a single-shot timer is created and delta values accumalated
     // from all wheelEvents fired during that timer. When the timer is not active, the scroll is
     // performed using the accumalated delta value. This is a temporary fix until QTBug-226 is fixed.
-//    this->m_scrollDelta += _event->delta();
-//    if (!m_scrollTimerActive) {
-//        float scalingStep = 0.9;
-//        if(this->m_scrollDelta < 0)
-//        {
-//            this->zoom(scalingStep);
-//        }
-//        else
-//        {
-//            this->zoom(1/scalingStep);
-//        }
+    this->m_scrollDelta += _event->delta();
+    if (!m_scrollTimerActive) {
+        float scalingStep = 0.9;
+        if(this->m_scrollDelta < 0)
+        {
+            this->zoom(scalingStep);
+        }
+        else
+        {
+            this->zoom(1/scalingStep);
+        }
 
-//        this->m_scrollDelta = 0;
-//        this->m_scrollTimerActive = true;
-//        QTimer::singleShot(23, this, [=]() {
-//            this->m_scrollTimerActive = false;
-//        });
-//    }
+        this->m_scrollDelta = 0;
+        this->m_scrollTimerActive = true;
+        QTimer::singleShot(23, this, [=]() {
+            this->m_scrollTimerActive = false;
+        });
+    }
 }
 
 void NodeEditor::keyPressEvent(

--- a/src/NodeEditor/NodeEditor.cpp
+++ b/src/NodeEditor/NodeEditor.cpp
@@ -51,9 +51,7 @@ NodeEditor::NodeEditor(
     m_lastClickedPoint(QPointF(0, 0)),
     m_fileName(QString()),
 //    m_newSelection(0),
-    m_treeModel(0),
-    m_scrollTimerActive(false),
-    m_scrollDelta(0)
+    m_treeModel(0)
 {
     /// @todo when pressed 'backspace' in file name label, last clicked node is deleted #fix
     /// @todo info 'tooltip' options
@@ -254,34 +252,6 @@ bool NodeEditor::eventFilter(
     }
     viewport()->update();
     return QObject::eventFilter(_object, _event);
-}
-
-void NodeEditor::wheelEvent(
-        QWheelEvent* _event
-        )
-{
-    //// @note Scrollwheel zoom disabled until upstream Qt bugs are fixed or suitable work-around is found
-    // When a wheelEvent is fired, a single-shot timer is created and delta values accumalated
-    // from all wheelEvents fired during that timer. When the timer is not active, the scroll is
-    // performed using the accumalated delta value. This is a temporary fix until QTBug-226 is fixed.
-    this->m_scrollDelta += _event->delta();
-    if (!m_scrollTimerActive) {
-        float scalingStep = 0.9;
-        if(this->m_scrollDelta < 0)
-        {
-            this->zoom(scalingStep);
-        }
-        else
-        {
-            this->zoom(1/scalingStep);
-        }
-
-        this->m_scrollDelta = 0;
-        this->m_scrollTimerActive = true;
-        QTimer::singleShot(23, this, [=]() {
-            this->m_scrollTimerActive = false;
-        });
-    }
 }
 
 void NodeEditor::keyPressEvent(


### PR DESCRIPTION
This pull request adds several new ways for a user to zoom.

Firstly, standard keyboard shortcuts for zoom in/out have been implemented (Ctrl++ for zoom in, Ctrl+- for zoom out and Cmd key used on Macs), along with their respective in the menu bar (under View).

Secondly, a pair of buttons has been added to the lower-left corner of the node editor allowing the user to zoom in and out.

This should hopefully improve the UX for all users, particularly Mac users who had no alternatives to mouse wheel scrolling.

Fixes #20 